### PR TITLE
Install plugin using kcoreaddons (fixes #36)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ktexteditor_wakatime)
 
 set(QT_MAJOR_VERSION "6")
 set(QT_MIN_VERSION "6.5.0")
-set(KF5_DEP_VERSION "6.0.0")
+set(KF_DEP_VERSION "6.0.0")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -12,13 +12,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 add_definitions(-DTRANSLATION_DOMAIN=\"katewakatime\")
 
-find_package(ECM ${KF5_DEP_VERSION} REQUIRED NO_MODULE)
+find_package(ECM ${KF_DEP_VERSION} REQUIRED NO_MODULE)
 list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 
+include(KDEInstallDirs6)
+include(KDECMakeSettings)
 include(ECMInstallIcons)
 include(KDECompilerSettings NO_POLICY_SCOPE)
-include(KDEInstallDirs)
-include(KDECMakeSettings)
 
 # Sane flags from Kate project
 add_definitions(
@@ -35,19 +35,24 @@ add_definitions(
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(Qt6Sql REQUIRED)
-find_package(KF6 ${KF5_DEP_VERSION} REQUIRED COMPONENTS I18n TextEditor)
+find_package(KF6 ${KF_DEP_VERSION} REQUIRED COMPONENTS I18n TextEditor CoreAddons)
 
 set(ktexteditor_wakatime_SRCS wakatimeplugin.cpp offlinequeue.cpp)
 
 ki18n_wrap_ui(ktexteditor_wakatime_SRCS configdialog.ui)
 qt6_add_resources(ktexteditor_wakatime_SRCS plugin.qrc)
 
-add_library(ktexteditor_wakatime MODULE ${ktexteditor_wakatime_SRCS})
+kcoreaddons_add_plugin(ktexteditor_wakatime
+    INSTALL_NAMESPACE "kf6/ktexteditor"
+    SOURCES ${ktexteditor_wakatime_SRCS}
+)
 
-target_link_libraries(ktexteditor_wakatime KF6::I18n KF6::TextEditor Qt6::Sql)
-
-install(TARGETS ktexteditor_wakatime
-        DESTINATION ${PLUGIN_INSTALL_DIR}/ktexteditor)
+target_link_libraries(ktexteditor_wakatime
+    KF6::I18n
+    KF6::TextEditor
+    KF6::CoreAddons
+    Qt6::Sql
+)
 
 set(WAKATIME_ICONS
     ${CMAKE_CURRENT_SOURCE_DIR}/icons/512-apps-wakatime.png
@@ -58,7 +63,8 @@ set(WAKATIME_ICONS
     ${CMAKE_CURRENT_SOURCE_DIR}/icons/256-apps-wakatime.png
     ${CMAKE_CURRENT_SOURCE_DIR}/icons/32-apps-wakatime.png
     ${CMAKE_CURRENT_SOURCE_DIR}/icons/48-apps-wakatime.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/icons/64-apps-wakatime.png)
+    ${CMAKE_CURRENT_SOURCE_DIR}/icons/64-apps-wakatime.png
+)
 
 ecm_install_icons(ICONS ${WAKATIME_ICONS} DESTINATION ${KDE_INSTALL_ICONDIR}
                   THEME hicolor)


### PR DESCRIPTION
Instead of `add_library` use `kcoreaddons_add_plugin` from CoreAddons, so that the plugin is installed to the proper directory. 

Currently the plugin attempts to install to the root directory `/ktexteditor/ktexteditor_wakatime.so`, causing it not to be used by Kate. See #36 